### PR TITLE
Fix positioning of Expand button

### DIFF
--- a/blockly.html
+++ b/blockly.html
@@ -787,6 +787,12 @@
                 id: "node-blockly-tab-workspace",
                 label: "Editor"
             });
+
+            // Put the expand button on top of the workspace tab
+            let expand_button = $('<div style="position: absolute; left: calc(100% - 20px - 5px); top: -1px; z-index: 99;">');
+            expand_button.append($('<button id="blocklyExpandDiv" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button>'));
+            $('#red-ui-tab-node-blockly-tab-workspace').append(expand_button);
+
             tabs.addTab({
                 id: "node-blockly-tab-javascript",
                 label: "Generated Javascript"
@@ -1070,9 +1076,6 @@
                 <!-- Blockly editor -->
                 <div id="blocklyArea" style="width: 100%; height: 450px; min-height:350px;">
                     <div id="blocklyDiv"></div>
-                    <div style="position: absolute; left:188px; bottom: calc(100% - 151px); z-index: 99;">
-                        <button id="blocklyExpandDiv" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Looks like the expand button used to be part of the workspace area - then moved to save screen space.
I've changed its position in the DOM tree; now it's a child of the "Editor" tab - simplifying the positioning.
Confirmed to be ok on NR3.1 & NR4.0-beta - respecting as well changes of the width of the tab:

![expandbutton](https://github.com/bartbutenaers/node-red-contrib-blockly/assets/16342003/b752b406-9e1a-425a-b7c5-f1e2dfe9d0fb)

Contributes to #106 