### PR TITLE
fix blockly workspace serialization

### DIFF
--- a/blockly.html
+++ b/blockly.html
@@ -225,17 +225,7 @@
 
             // Create the workspace as soon as the last script has been loaded.  
             // This is possible because the scripts are loaded sequentially (via async = false)
-            if (node.workspace) {
-                // When there has been a previous workspace, show the content of that workspace.
-                // Because that workspace might have changes (which have not been stored yet into node.workspaceXml), which need to be kept
-                var dom = Blockly.Xml.workspaceToDom(node.workspace);
-                var originalXml = Blockly.Xml.domToPrettyText(dom);
-                createWorkspace(node, originalXml);
-            }
-            else {
-                // Since their is no previous workspace, let's show the last stored xml
-                createWorkspace(node, node.workspaceXml);
-            }                
+            createWorkspace(node, node.workspaceXml);
         }
     }
 
@@ -972,6 +962,13 @@
                 // it that way, missing sentences in the translations are not a problem (since those sentences will simply be displayed in english).
                 // CAUTION: the "blockly-contrib/npm/blockly/msg/en.js" file contains a Blockly.Msg = {} , which means all previous loaded 
                 // messages will be removed!
+                if (node.workspace) {
+                    // When there has been a previous workspace, show the content of that workspace.
+                    // Because that workspace might have changes (which have not been stored yet into node.workspaceXml), which need to be kept
+
+                    var dom = Blockly.Xml.workspaceToDom(node.workspace);
+                    node.workspaceXml = Blockly.Xml.domToPrettyText(dom);
+                }
                 loadResourcesFromServer(node, language, categories);
             });
             // This is being called by Node-RED also $("#node-input-blocklyConfig").change();


### PR DESCRIPTION
This serializes the Blockly workspace before Blockly gets reinitialized.  This should fix https://groups.google.com/g/blockly/c/Rc5WiS8J1kc

This is a best effort PR so please do more testing

The issue is that `loadResourcesFromServer` is called multiple times, and each time a new Blockly instance is created.

So this is what happens:

loadResourcesFromServer is called and Blockly instance A is created
A creates workspace W1
loadResourcesFromServer is called again and Blockly instance B is created
B is used to serialize W1 (created by A) into XML and fails

This is a temporary fix that uses A to serialize W1 so B can use the serialized xml to create a new workspace.
Ideally we should not be loading Blockly more than once but i'll leave it up to you.